### PR TITLE
Fix syntax error with Cookie header in HTTP resquest

### DIFF
--- a/livebox/livebox.py
+++ b/livebox/livebox.py
@@ -66,7 +66,7 @@ class Livebox:
 
 			
 		req = urllib2.Request(url, params)
-		req.add_header('Cookies', self._cookies)
+		req.add_header('Cookie', self._cookies)
 		req.add_header('X-Context', self._contextID)
 		req.add_header('X-Sah-Request-Type', 'idle')
 		req.add_header('Content-Type', content_type)


### PR DESCRIPTION
I discovered a little error in passing the cookie header to livebox during authenticated requests
This cause the livebox doesn't considers the script as granted to access private API
